### PR TITLE
Fix mutation bugs and missing license/person handling

### DIFF
--- a/src/__tests__/createLicenseHeader.test.ts
+++ b/src/__tests__/createLicenseHeader.test.ts
@@ -331,6 +331,24 @@ it('multi versions: some same info', () => {
   ).toMatchSnapshot()
 })
 
+it('does not mutate input array order', () => {
+  const pkgs = [
+    { name: 'c', version: '2.0.0', license: 'MIT' },
+    { name: 'c', version: '1.0.0', license: 'MIT' },
+  ]
+  createLicenseHeader({ deps: { c: pkgs } })
+  expect(pkgs[0].version).toBe('2.0.0')
+  expect(pkgs[1].version).toBe('1.0.0')
+})
+
+it('does not mutate input objects when merging versions', () => {
+  const c1 = { name: 'c', version: '1.0.0', license: 'MIT' }
+  const c2 = { name: 'c', version: '2.0.0', license: 'MIT' }
+  createLicenseHeader({ deps: { c: [c1, c2] } })
+  expect(c1.version).toBe('1.0.0')
+  expect(c2.version).toBe('2.0.0')
+})
+
 it('multi versions: semver sort', () => {
   expect(
     createLicenseHeader({

--- a/src/__tests__/extract.test.ts
+++ b/src/__tests__/extract.test.ts
@@ -111,3 +111,18 @@ it('licenses is string', () => {
   const extracted = extract({ licenses: 'MIT' })
   expect(extracted.license).toBe('MIT')
 })
+
+it('licenses is array of strings', () => {
+  const extracted = extract({ licenses: ['MIT', 'Apache-2.0'] })
+  expect(extracted.license).toBe('MIT, Apache-2.0')
+})
+
+it('maintainers is string', () => {
+  const extracted = extract({ maintainers: 'foo' })
+  expect(extracted.maintainers).toBe('foo')
+})
+
+it('contributors is string', () => {
+  const extracted = extract({ contributors: 'foo' })
+  expect(extracted.contributors).toBe('foo')
+})

--- a/src/__tests__/extract.test.ts
+++ b/src/__tests__/extract.test.ts
@@ -79,3 +79,35 @@ it('homepage invalid url', () => {
   })
   expect(extracted.homepage).toBe('homepage')
 })
+
+it('name and version are passed through', () => {
+  const extracted = extract({ name: 'foo', version: '1.0.0' })
+  expect(extracted.name).toBe('foo')
+  expect(extracted.version).toBe('1.0.0')
+})
+
+it('private package', () => {
+  const extracted = extract({ private: true })
+  expect(extracted.private).toBe(true)
+  expect(extracted.name).toBeUndefined()
+})
+
+it('author is string', () => {
+  const extracted = extract({ author: 'foo' })
+  expect(extracted.author).toBe('foo')
+})
+
+it('author with email only (no name)', () => {
+  const extracted = extract({ author: { email: 'a@example.com' } })
+  expect(extracted.author).toBe('<a@example.com>')
+})
+
+it('author with neither name nor email', () => {
+  const extracted = extract({ author: {} })
+  expect(extracted.author).toBe('')
+})
+
+it('licenses is string', () => {
+  const extracted = extract({ licenses: 'MIT' })
+  expect(extracted.license).toBe('MIT')
+})

--- a/src/createLicenseHeader.ts
+++ b/src/createLicenseHeader.ts
@@ -30,7 +30,7 @@ export function createLicenseHeader({
           return createEachHeader(extract(depsPkgs))
         }
         const results: Package[] = []
-        depsPkgs
+        ;[...depsPkgs]
           .sort((a, b) => compare(a.version, b.version))
           .forEach((pkg) => {
             const samePkgs = results.filter(
@@ -45,7 +45,7 @@ export function createLicenseHeader({
             if (samePkgs.length) {
               samePkgs[0].version = `${samePkgs[0].version}, ${pkg.version}`
             } else {
-              results.push(pkg)
+              results.push({ ...pkg })
             }
           })
         return results.map((pkg, i) => createEachHeader(extract(pkg), { hierarchy: i === 0 ? 1 : 2 })).join('')

--- a/src/extract.ts
+++ b/src/extract.ts
@@ -4,9 +4,9 @@ import { URL } from 'url'
 function extractPerson(person: string | Person) {
   if (typeof person === 'object') {
     if (person.email) {
-      return `${person.name} <${person.email}>`
+      return person.name ? `${person.name} <${person.email}>` : `<${person.email}>`
     }
-    return person.name
+    return person.name ?? ''
   }
   return person
 }
@@ -43,6 +43,8 @@ export function extract(pkg: Package): Package {
     version: pkg.version,
     license: Array.isArray(pkg.licenses)
       ? pkg.licenses.map(extractLicense).join(', ')
+      : typeof pkg.licenses === 'string'
+      ? pkg.licenses
       : pkg.license
       ? extractLicense(pkg.license)
       : pkg.license,


### PR DESCRIPTION
## Summary

Fixes 4 bugs identified in code review, developed via TDD (tests added first, then bugs fixed to make them pass).

- **Bug #1** (`createLicenseHeader.ts`): `results` held references to original pkg objects, causing input objects to be mutated when merging versions — fixed by copying with `{ ...pkg }` on push
- **Bug #2** (`createLicenseHeader.ts`): `Array.prototype.sort` mutated the caller's input array — fixed by spreading before sort (`[...depsPkgs].sort(...)`)
- **Bug #3** (`extract.ts`): `licenses` field as a string was silently dropped, falling through to `pkg.license` (which is undefined in that case) — fixed by handling the string case explicitly
- **Bug #4** (`extract.ts`): `extractPerson` returned `"undefined <email>"` when `name` was missing but `email` was present, and returned `undefined` when both were absent — fixed to return `<email>` or `''`

## Test plan

- [x] Added failing tests for each bug before fixing
- [x] All 33 tests pass with `npm test`

🤖 Generated with [Claude Code](https://claude.com/claude-code)