### PR TITLE
fix: make Package type's private branch require true literal

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -22,6 +22,6 @@ export type Package =
       [k: string]: any
     }
   | {
-      private?: boolean
+      private: true
       [k: string]: any
     }


### PR DESCRIPTION
## Summary

- The second union branch `{ private?: boolean; [k: string]: any }` of the `Package` type matched every object, effectively nullifying the `name`/`version` required constraints in the first branch
- Fixed by narrowing the discriminant to `private: true`

## Changes

Only `src/types.ts`:

```diff
- private?: boolean
+ private: true
```

## Why this fixes it

- `{ name: 'foo' }` no longer matches the second union branch since `private: true` is now required
- It also won't match the first branch without `version`, so missing required fields correctly produce a type error
- `[k: string]: any` remains on both branches, so existing property accesses (`pkg.name`, `pkg.private`, etc.) need no changes

## Test plan

- [x] `npx tsc --noEmit` — no type errors
- [x] `npx vitest run` — all 36 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)